### PR TITLE
Disabling rule `css-modules/no-unused-class`

### DIFF
--- a/eslintrc.js
+++ b/eslintrc.js
@@ -10,7 +10,12 @@ module.exports = {
     'compat/compat': ['error'],
 
     // CSS Modules
-    'css-modules/no-unused-class': ['error'],
+
+    // Disabling rule as it does not play nicely
+    // with the pattern of multiple components
+    // importing single css file
+    //'css-modules/no-unused-class': ['error'],
+
     'css-modules/no-undef-class': ['error'],
 
     // JsDoc


### PR DESCRIPTION
Disabling rule as it does not play nicely with the pattern of multiple components importing single css file.

## Example 
```scss
// ComponentStyle.scss
.a {
  // styles
}

.b {
  // styles
}
```
```jsx
// Component A 

import styles from 'ComponentStyle.scss'

render() {
  return <div style={ styles.a }/>
}
```

```jsx
// Component B 

import styles from 'ComponentStyle.scss'

render() {
  return <div style={ styles.b }/>
}
```